### PR TITLE
repo: Point submodule to cyanodbc/nanodbc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/cython/nanodbc"]
 	path = src/cython/nanodbc
-	url = https://github.com/detule/nanodbc
+	url = https://github.com/cyanodbc/nanodbc
 	branch = cyanodbc


### PR DESCRIPTION
Hi @rdhushyanth 

As discussed - pointing the submodule to point to the nanodbc fork within the cyanodbc organization.