### PR TITLE
repo: nanodbc: catch-up submodule to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/cython/nanodbc"]
 	path = src/cython/nanodbc
 	url = https://github.com/cyanodbc/nanodbc
-	branch = cyanodbc
+	branch = cyanodbc-0.0.2


### PR DESCRIPTION
Hi @rdhushyanth:

This PR is house-keeping for the nanodbc submodule.

* Caught up our nanodbc submodule to upstream (some important fixes), and rebased our two "in-house" patches on top of the new tip.

* Changed submodule to track branch 'cyanodbc-0.0.2' in our forked nanodbc repo. So that once we release v0.0.2 we can freeze the branch we are tracking - and not update it again.  Post v0.0.2 release, we would need to start tracking a branch 'cyanodbc-0.0.3' in the forked repo, and so on.