### PR TITLE
Prcandidate/datasources unbind

### DIFF
--- a/src/cython/cyanodbc/_cyanodbc.pyx
+++ b/src/cython/cyanodbc/_cyanodbc.pyx
@@ -12,6 +12,7 @@ import numbers
 import time
 import traceback
 import itertools
+import re
 from libcpp.memory cimport unique_ptr
 from cython.operator cimport dereference as deref
 

--- a/src/cython/cyanodbc/connection.pxi
+++ b/src/cython/cyanodbc/connection.pxi
@@ -265,3 +265,10 @@ def connect(dsn, username=None, password=None, long timeout=0):
     cnxn = Connection()
     cnxn._connect(dsn, username, password, timeout)
     return cnxn
+
+def datasources():
+    out = {}
+    res = nanodbc.list_datasources()
+    for r in res:
+        out.update({ r.name.decode() : r.driver.decode() })
+    return out

--- a/src/cython/cyanodbc/cursor.pxi
+++ b/src/cython/cyanodbc/cursor.pxi
@@ -1,5 +1,4 @@
 
-
 ColumnDescription = namedtuple(
     'ColumnDescription',
     ['name', 'type_code', 'display_size', 'internal_size', 'precision', 'scale', 'null_ok'],
@@ -70,7 +69,17 @@ cdef class Cursor:
         # return <object>nanodbc.PyUnicode_FromWideChar(ptr, -1)
         with decimal.localcontext() as ctx:
             ctx.prec = deref(self.c_result_ptr).column_decimal_digits(i)   # Perform a high precision calculation
-            return decimal.Decimal(deref(self.c_result_ptr).get[string](i).decode())
+            # There is a bug/limitation in ODBC drivers for SQL Server
+            # (and possibly others) which causes SQLBindCol() to never
+            # write SQL_NOT_NULL to the length/indicator buffer unless you
+            # also bind the data column. nanodbc's is_null() will return
+            # correct values for these columns if you ensure that
+            # SQLGetData() has been called for that column (i.e. *after* get()
+            # or get_ref() is called).
+            res = deref(self.c_result_ptr).get[string](i).decode()
+            if deref(self.c_result_ptr).is_null(i):
+                return None
+            return decimal.Decimal(res)
 
     def _float_to_py(self, short i):
         return deref(self.c_result_ptr).get[double](i) # python float == C double
@@ -81,6 +90,8 @@ cdef class Cursor:
     def _datetime_to_py(self, short i):
         cdef nanodbc.timestamp c_timestamp
         c_timestamp = deref(self.c_result_ptr).get[nanodbc.timestamp](i)
+        if deref(self.c_result_ptr).is_null(i):
+            return None
         # Maybe if Time component is Zero return Date, else Datetime? - But what about TZ?
         return cpython.datetime.datetime_new(c_timestamp.year,c_timestamp.month,
             c_timestamp.day, c_timestamp.hour, c_timestamp.min,
@@ -89,8 +100,22 @@ cdef class Cursor:
     def _time_to_py(self, short i):
         cdef nanodbc.time c_time
         c_time = deref(self.c_result_ptr).get[nanodbc.time](i)
+        if deref(self.c_result_ptr).is_null(i):
+            return None
         return cpython.datetime.time_new(c_time.hour, c_time.min, c_time.sec, 0, None)
-    
+
+    def _unbind_if_needed(self):
+        found_unbound = False
+        try:
+            if not self.c_result_ptr or self._connection.get_data_any_order:
+                return
+            for i in range(deref(self.c_result_ptr).columns()):
+                is_bound = deref(self.c_result_ptr).is_bound(i)
+                if found_unbound and is_bound:
+                    deref(self.c_result_ptr).unbind(i)
+                found_unbound = found_unbound or (not is_bound)
+        except RuntimeError as e:
+            raise DatabaseError("Error while unbinding: " + str(e)) from e
 
     def __cinit__(self):
         self._arraysize = 1
@@ -181,7 +206,7 @@ cdef class Cursor:
             deref(self.c_stmt_ptr).bind_strings(idx, values, <bool_*>nulls.data(), nanodbc.param_direction.PARAM_IN)
         try:
             self.c_result_ptr.reset(new nanodbc.result(deref(self.c_stmt_ptr).execute(max(1, len(seq_of_parameters)), self.timeout)))
-            
+
         except RuntimeError as e:
             raise DatabaseError("Error in Executing: " + str(e)) from e
         
@@ -235,6 +260,7 @@ cdef class Cursor:
         cdef short i
         Row = None
         _ = self.description # Initialise self.c_description
+        self._unbind_if_needed()
         try:
             while deref(self.c_result_ptr).next():
                 if Row is None:

--- a/src/cython/cyanodbc/cursor.pxi
+++ b/src/cython/cyanodbc/cursor.pxi
@@ -198,6 +198,7 @@ cdef class Cursor:
         for col, idx in zip(transpose, itertools.count()):
             # values = vector[string](len(col))
             # print(idx, list(col))
+            values.clear()
 
             [values.push_back(str(i).encode()) for i in col]
 

--- a/src/cython/cyanodbc/nanodbc.pxd
+++ b/src/cython/cyanodbc/nanodbc.pxd
@@ -49,7 +49,12 @@ cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc":
     ctypedef wstring wide_string
 
     result execute(connection& conn, const string& query, long batch_operations, long timeout) except +
+    list_[datasource] list_datasources() except +
     
+    cdef cppclass datasource:
+        string name
+        string driver
+
     cdef cppclass date:
         int16_t year
         int16_t month

--- a/src/cython/cyanodbc/nanodbc.pxd
+++ b/src/cython/cyanodbc/nanodbc.pxd
@@ -89,6 +89,9 @@ cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc":
         bint last()
         bint next() except +
         bint is_null(short column) except +
+        bool_ is_bound(short column) except +
+        void unbind(short column) except +
+        void unbind() except +
 
         T get[T](short column) except+
         short column(const string& column_name) const


### PR DESCRIPTION
Hi @rdhushyanth 

Nearing the end of what I have locally in terms of patches - thank you for your patience in reviewing / merging.

There are four commits here - thematically distinct to warrant separate PRs perhaps - happy to break them up if you wish.

1. Wrap nanodbc's `datasources` method - interacts with the driver manager which in turn returns system and user defined data sources.
2. This is a pretty important one - allows cyanodbc to be paired with the OEM MSFT driver for SQL server.  Without the patch there is a high probability of failure with even a simple "SELECT *", if the table you are querying has long data columns that are not at the end of the table.  Well documented in various issues on the nanodbc repo.
3. Bugfix in execution of parametrized queries.
4. Small optimization.