### PR TITLE
cicd: travis: fixup deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,8 +141,13 @@ script:
   - pytest --cov=cyanodbc $TRAVIS_BUILD_DIR/tests
 
 deploy:
-  skip_cleanup: true
-  provider: script
-  script: $TRAVIS_BUILD_DIR/ci/travis/deploy.sh
-  on:
-    branches: master
+  - provider: script
+    skip_cleanup: true
+    script: $TRAVIS_BUILD_DIR/ci/travis/deploy.sh
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: $TRAVIS_BUILD_DIR/ci/travis/deploy.sh
+    on:
+      tags: true


### PR DESCRIPTION
Hi @rdhushyanth 

This is an attempt to fixup the travis deployment on tags - unlike appveyor, travis apparently can't associate tags with branches so we need two deployment providers here.

Some of this is guesswork, since testing this bit in a fork is a bit challenging - we'll have a better idea if there are any outstanding issues once we try to actually tag the repo.