### PR TITLE
Fixup/decimal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,12 @@ before_install:
   - python -m pip install --upgrade pip
   - conda install -q -y cmake pytest cython ninja pytest-cov twine
   - conda install -q -y -c conda-forge codecov distro
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew services run postgresql; fi
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew services run postgresql
+      sleep 10
+      createuser -s postgres
+    fi
 
 script:
   - cd $TRAVIS_BUILD_DIR

--- a/src/cython/cyanodbc/cursor.pxi
+++ b/src/cython/cyanodbc/cursor.pxi
@@ -68,7 +68,8 @@ cdef class Cursor:
         # cdef const_wchar_t *ptr = deref(self.c_result_ptr).get[nanodbc.wide_string](i).c_str()
         # return <object>nanodbc.PyUnicode_FromWideChar(ptr, -1)
         with decimal.localcontext() as ctx:
-            ctx.prec = deref(self.c_result_ptr).column_decimal_digits(i)   # Perform a high precision calculation
+            # Perform a high precision calculation
+            ctx.prec = max(1, deref(self.c_result_ptr).column_decimal_digits(i))
             # There is a bug/limitation in ODBC drivers for SQL Server
             # (and possibly others) which causes SQLBindCol() to never
             # write SQL_NOT_NULL to the length/indicator buffer unless you

--- a/tests/test_dbapi_postgres.py
+++ b/tests/test_dbapi_postgres.py
@@ -1,0 +1,24 @@
+import cyanodbc
+import dbapi20
+import pytest
+import sys
+
+@pytest.mark.skipif(sys.platform not in ["darwin", "Darwin"], reason = "postgreSQL Unavailable")
+class CyanodbcDBApiTest(dbapi20.DatabaseAPI20Test):
+    driver = cyanodbc
+    connect_args = ("Driver={PostgreSQL ODBC Driver(UNICODE)};Server=localhost;UID=postgres;Port=5432;Database=postgres", )
+    ""
+
+    def test_setoutputsize(self):
+        pass
+
+    def test_nextset(self):
+        pass # for sqlite no nextset()
+
+    @pytest.mark.skip(reason = "PSQL odbc driver returns rowcount 0 after CREATE TABLE")
+    def test_rowcount():
+        super().test_rowcount()
+
+    @pytest.mark.skip(reason = "PSQL odbc driver returns rowcount 1 inserting two rows with prepared statement")
+    def test_executemany():
+        super().test_executemany()


### PR DESCRIPTION
Hi @rdhushyanth 

This PR is mainly a bugfix to `_numeric_to_py` in the event that precision is < 1.  In the process I also added the dbapi2.0 postgres test (on OSX only at this point). 