### PR TITLE
*.pxi: release GIL ahead of I/O

### DIFF
--- a/src/cython/cyanodbc/cursor.pxi
+++ b/src/cython/cyanodbc/cursor.pxi
@@ -198,7 +198,7 @@ cdef class Cursor:
     def executemany(self, query, seq_of_parameters):
         cdef vector[string] values
         cdef vector[char] nulls
-        cdef short i
+        cdef short c_idx
         cdef long batch_operations
         cdef long timeout
 
@@ -222,9 +222,9 @@ cdef class Cursor:
             [values.push_back(str(i).encode()) for i in col]
 
             [nulls.push_back(True) if i is None else nulls.push_back(False) for i in col ]
-            i = idx
+            c_idx = idx
             with nogil:
-                deref(self.c_stmt_ptr).bind_strings(i, values, <bool_*>nulls.data(), nanodbc.param_direction.PARAM_IN)
+                deref(self.c_stmt_ptr).bind_strings(c_idx, values, <bool_*>nulls.data(), nanodbc.param_direction.PARAM_IN)
 
         batch_operations = max(1, len(seq_of_parameters))
         timeout = self.timeout

--- a/src/cython/cyanodbc/nanodbc.pxd
+++ b/src/cython/cyanodbc/nanodbc.pxd
@@ -15,7 +15,7 @@ cdef extern from "Python.h":
     PyObject* PyUnicode_FromWideChar(wchar_t *w, Py_ssize_t size)
     PyObject* PyBytes_FromStringAndSize(const char *v, Py_ssize_t len)
 
-cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc::catalog":
+cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc::catalog" nogil:
    cdef cppclass tables:
         tables(tables&)
         bool_ next()
@@ -45,7 +45,7 @@ cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc::catalog":
         short sql_datetime_subtype() const
         long char_octet_length() const
 
-cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc":
+cdef extern from "nanodbc/nanodbc.h" namespace "nanodbc" nogil:
     ctypedef wstring wide_string
 
     result execute(connection& conn, const string& query, long batch_operations, long timeout) except +


### PR DESCRIPTION
Hi @rdhushyanth 

This should facilitate better behavior in multi-threaded applications - intention is that I/O operations with the server do not block all threads.