### PR TITLE
cicd: travis/appveyor: Add rfc3986 package for twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ before_install:
   - source $HOME/miniconda/bin/activate mypy
   - python -m pip install --upgrade pip
   - conda install -q -y cmake pytest cython ninja pytest-cov twine
-  - conda install -q -y -c conda-forge codecov distro
+  - conda install -q -y -c conda-forge codecov distro rfc3986
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew services run postgresql

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ install:
   - cmd: call activate mypy
   - cmd: conda install -q -y cmake pytest cython ninja pytest-cov twine
   - cmd: python -m pip install --upgrade pip
-  - cmd: conda install -q -y -c conda-forge distro
+  - cmd: conda install -q -y -c conda-forge distro rfc3986
   - cmd: conda deactivate
   - cmd: curl -fsS -o sqliteodbc_w64.exe http://www.ch-werner.de/sqliteodbc/sqliteodbc_w64.exe
   - cmd: sqliteodbc_w64.exe /S


### PR DESCRIPTION
HI @rdhushyanth 

An attempt to fix the `twine/travis` deployment failure on master.

Thank you!