### PR TITLE
cicd: travis/appveyor: Add keyring package for twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ before_install:
   - conda create -q -y -n mypy python=${PYTHONVER}
   - source $HOME/miniconda/bin/activate mypy
   - python -m pip install --upgrade pip
-  - conda install -q -y cmake pytest cython ninja pytest-cov twine
+  - conda install -q -y cmake pytest cython ninja pytest-cov twine keyring
   - conda install -q -y -c conda-forge codecov distro rfc3986
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - cmd: set PATH=%PATH%;C:\Miniconda3-x64;C:\Miniconda3-x64\Scripts
   - cmd: conda create -q -y -n mypy python=%PYTHONVER%
   - cmd: call activate mypy
-  - cmd: conda install -q -y cmake pytest cython ninja pytest-cov twine
+  - cmd: conda install -q -y cmake pytest cython ninja pytest-cov twine keyring
   - cmd: python -m pip install --upgrade pip
   - cmd: conda install -q -y -c conda-forge distro rfc3986
   - cmd: conda deactivate


### PR DESCRIPTION
Hi @rdhushyanth 

Sorry to keep pinging you here as I work through these CI issues - looks like there have been some updates to `twine` since the last time we uploaded anything to pypi.

Hopefully the wheel deploys fine after this.